### PR TITLE
Fix crashing from PlayerEntityMixin

### DIFF
--- a/src/main/java/org/oakbricks/oakores/mixin/EntityAccessor.java
+++ b/src/main/java/org/oakbricks/oakores/mixin/EntityAccessor.java
@@ -1,0 +1,13 @@
+package org.oakbricks.oakores.mixin;
+
+import net.minecraft.entity.Entity;
+
+import net.minecraft.world.World;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Accessor;
+
+@Mixin(Entity.class)
+public interface EntityAccessor {
+    @Accessor
+    World getWorld();
+}

--- a/src/main/java/org/oakbricks/oakores/mixin/PlayerEntityMixin.java
+++ b/src/main/java/org/oakbricks/oakores/mixin/PlayerEntityMixin.java
@@ -28,17 +28,12 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import static java.lang.Thread.sleep;
 
 @Mixin(LivingEntity.class)
-public abstract class PlayerEntityMixin {
+public abstract class PlayerEntityMixin implements EntityAccessor {
+    @Shadow public abstract ItemStack getMainHandStack();
 
-    @Shadow
-    public abstract ItemStack getMainHandStack();
+    @Shadow public abstract ItemStack getOffHandStack();
 
-    @Shadow
-    public abstract ItemStack getOffHandStack();
-
-    public Entity entity;
-
-    public World world;
+    @Shadow public abstract boolean addStatusEffect(StatusEffectInstance effect);
 
     public abstract int maxLeadTimeAllowed();
 
@@ -51,17 +46,10 @@ public abstract class PlayerEntityMixin {
 
     @Inject(at = @At("HEAD"), method = "tick")
     public void leadOnTick(CallbackInfo ci) {
-
-        if (this.getMainHandStack().isOf(ItemClass.LEAD_ROCK) || getOffHandStack().isOf(ItemClass.LEAD_ROCK) && this.ticks == this.maxLeadTimeAllowed() && world.getDifficulty() != Difficulty.PEACEFUL) {
-
-
+        if (this.getMainHandStack().isOf(ItemClass.LEAD_ROCK) || this.getOffHandStack().isOf(ItemClass.LEAD_ROCK) && this.ticks == this.maxLeadTimeAllowed() && this.getWorld().getDifficulty() != Difficulty.PEACEFUL) {
             if (this.ticks > this.maxLeadTimeAllowed()) {
-                LivingEntity livingEntity = (LivingEntity)entity;
-                if (entity instanceof LivingEntity) {
-                    livingEntity.addStatusEffect(new StatusEffectInstance(StatusEffects.WEAKNESS, 50));
-                }
+                this.addStatusEffect(new StatusEffectInstance(StatusEffects.WEAKNESS, 50));
             }
-
         }
     }
 }

--- a/src/main/resources/oakores.mixins.json
+++ b/src/main/resources/oakores.mixins.json
@@ -5,6 +5,7 @@
   "compatibilityLevel": "JAVA_16",
   "mixins": [
     "ArmorItemMixin",
+    "EntityAccessor",
     "PlayerEntityMixin"
   ],
   "client": [


### PR DESCRIPTION
This fixes the crashing that was occurring because world access was broken in PlayerEntityMixin. I am unable to test whether the rest of the code logic is correct because I wasn't able to find any lead in the world or give myself any with a command.